### PR TITLE
On windows platform, if folder depth is more than 2 (example: more\th…

### DIFF
--- a/lib/hbs.js
+++ b/lib/hbs.js
@@ -179,7 +179,7 @@ ExpressHbs.prototype.cachePartials = function(cb) {
       var dirname = path.dirname(entry.path);
       dirname = dirname === '.' ? '' : dirname + '/';
 
-      var name = dirname + path.basename(entry.name, path.extname(entry.name));
+      var name = (dirname + path.basename(entry.name, path.extname(entry.name))).replace('\\', '/');
       self.registerPartial(name, source, entry.fullPath);
     })
     .on('end', function() {


### PR DESCRIPTION
…an\two\depth\foobar.html),  only the last path delimiter will change to `/` , and the partial name will be `more\than\two\depth/foobar`, that will lead to not find the partial.

so, changing all `\` to `/` to make delimiters consistent.
